### PR TITLE
Desafio Juliano Sudecum turma 060430_20261_21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # UnisinosGCS
 Repositório da Disciplina de GCS
+
+Nome: Juliano Sudecum; Ano/Semestre: 2026/1; Cadeira: Gerência da Configuração de Software; Código da Turma: 060430_20261_21.


### PR DESCRIPTION
## Resumo
Adiciona ao README.md as informações de identificação do aluno, conforme solicitado no desafio da disciplina de Gerência da Configuração de Software.

## Alterações
- Nome: Juliano Sudecum
- Ano/Semestre: 2026/1
- Código da Turma: 060430_20261_21

## Plano de teste
- [x] README.md renderiza corretamente no GitHub
- [x] Linha adicionada segue o padrão usado pelos demais alunos