### PR TITLE
docs: adiciona nome de Carlos Eduardo Flores- 2026/1 - (060430_20261_20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # UnisinosGCS
 Repositório da Disciplina de GCS
+## Contribuidores
+
+| Nome Completo         | Ano/Semestre | Código da Turma |
+|-----------------------|--------------|-----------------|
+| Carlos Eduardo Flores    | 2026/1       |(060430_20261_20)|


### PR DESCRIPTION
Inclusão de nome completo, ano/semestre e código de turma no README.md conforme atividade proposta na disciplina de GCS.

- Nome: Carlos Eduardo Flores
- Ano/Semestre: 2026/1
- Turma:  (060430_20261_20)